### PR TITLE
Fix Markdown documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Only sanity tests are under the `t/` directory. Extensive tests are under `xt/`.
 Some tests require an online connection. The tests can be run offline by setting the environment variable TEST_OFFLINE, eg. `TEST_OFFLINE=1 prove6 -I. xt/`.
 
 # More Information
-See [RenderPod](RenderPod.md) for the generic module and [Pod2HTML](Pod2HTML.md) for information about the HTML specific module ``Pod::To::HTML2``. ``Pod::To::Markdown``, see [MarkDown](MarkDown.md), follows ``Pod::To::HTML2`` mostly.
+See [RenderPod](RenderPod.md) for the generic module and [Pod2HTML](Pod2HTML.md) for information about the HTML specific module ``Pod::To::HTML2``. ``Pod::To::Markdown``, see [MarkDown2](MarkDown2.md), follows ``Pod::To::HTML2`` mostly.
 
 
 

--- a/doc/README.rakudoc
+++ b/doc/README.rakudoc
@@ -136,6 +136,6 @@ environment variable TEST_OFFLINE, eg. C<TEST_OFFLINE=1 prove6 -I. xt/>.
 
 See L<RenderPod> for the generic module and L<Pod2HTML> for
 information about the HTML 
-specific module `Pod::To::HTML2`. `Pod::To::Markdown`, see L<MarkDown>, follows `Pod::To::HTML2` mostly.
+specific module `Pod::To::HTML2`. `Pod::To::Markdown`, see L<MarkDown2>, follows `Pod::To::HTML2` mostly.
 
 =end pod


### PR DESCRIPTION
Hello,

I didn't actually regenerate the file, just added the fixed link so that it can show up on github and raku.land if anybody wants to check it out. It bit me two times at least. :P